### PR TITLE
Improve loader for stacked spectrogram arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,14 @@ Run the GUI with:
 python main.py
 ```
 
-Use the interface to load one or more numpy arrays, apply average pooling, crop each spectrogram using the mouse and `c` key, and finally save all windows as a new array.
+Load one or more numpy arrays and they will be pooled immediately using the configured window size. Crop each spectrogram using the mouse and `c` key, then save all windows as a new array.
+
+### Accepted array layouts
+
+The loader can handle spectrograms stored individually as 2‑D arrays as well as files
+that stack multiple spectrograms along one axis. Supported shapes are:
+
+- ``(freq, time, n_spects)`` – stacks on the **last** axis
+- ``(n_spects, time, freq)`` – stacks on the **first** axis
+
+The loader automatically splits such arrays and loads each spectrogram individually.

--- a/main.py
+++ b/main.py
@@ -59,7 +59,8 @@ class SpectAnalyzer:
         self.spects = load_spects(list(paths))
         self.processed = self.spects.copy()
         self.index = 0
-        self.display_current()
+        # automatically pool for easier viewing
+        self.apply_pooling()
 
     def apply_pooling(self) -> None:
         if not self.spects:

--- a/spect_load.py
+++ b/spect_load.py
@@ -2,5 +2,29 @@ import numpy as np
 from typing import List
 
 def load_spects(paths: List[str]) -> List[np.ndarray]:
-    """Load multiple ``.npy`` files and return list of arrays."""
-    return [np.load(p) for p in paths]
+    """Load multiple ``.npy`` files and return list of 2D spectrogram arrays.
+
+    The application expects each spectrogram to be a 2D array.  If the loaded
+    data is 3‑D it may contain multiple spectrograms stacked either on the first
+    axis ``(n_spects, time, freq)`` or the last axis ``(freq, time, n_spects)``.
+    In those cases the array is split along the detected stack axis and each
+    slice is returned individually.
+    """
+
+    spects: List[np.ndarray] = []
+    for path in paths:
+        data = np.load(path)
+
+        if data.ndim == 3:
+            # Determine if spectrograms are stacked on the first or last axis.
+            first_is_stack = data.shape[0] < data.shape[1] and data.shape[0] < data.shape[2]
+            if first_is_stack:
+                for i in range(data.shape[0]):
+                    spects.append(data[i, ...])
+            else:
+                for i in range(data.shape[-1]):
+                    spects.append(data[..., i])
+        else:
+            spects.append(data)
+
+    return spects


### PR DESCRIPTION
## Summary
- detect stacked spectrograms on the first axis in `load_spects`
- auto-apply average pooling when files are loaded
- document automatic pooling in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6875fb8b5a388321a54ba389ab0df3da