### PR TITLE
Fix rectangle selector for new matplotlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ Load one or more numpy arrays and they will be pooled immediately using the conf
 
 ### Accepted array layouts
 
-The loader can handle spectrograms stored individually as 2‑D arrays as well as files
-that stack multiple spectrograms along one axis. Supported shapes are:
-
-- ``(freq, time, n_spects)`` – stacks on the **last** axis
-- ``(n_spects, time, freq)`` – stacks on the **first** axis
-
-The loader automatically splits such arrays and loads each spectrogram individually.
+The loader can handle spectrograms stored individually as 2‑D arrays as well as
+files that stack multiple spectrograms along the **first** axis. A stacked file
+must therefore have the shape ``(n_spects, freq, time)``. The application splits
+such arrays automatically and loads each spectrogram individually.

--- a/main.py
+++ b/main.py
@@ -95,13 +95,17 @@ class SpectAnalyzer:
 
         if self.selector:
             self.selector.disconnect_events()
+        kwargs = {
+            "useblit": True,
+            "button": [1],
+            "interactive": True,
+        }
+        if "drawtype" in RectangleSelector.__init__.__code__.co_varnames:
+            kwargs["drawtype"] = "box"
         self.selector = RectangleSelector(
             self.ax,
             onselect=lambda *args: None,
-            drawtype="box",
-            useblit=True,
-            button=[1],
-            interactive=True,
+            **kwargs,
         )
         self.canvas.draw()
 

--- a/spect_slice.py
+++ b/spect_slice.py
@@ -1,11 +1,11 @@
 import numpy as np
 from skimage import exposure, util
-from typing import Iterable, List, Tuple
+from typing import List, Tuple
 
 
 def average_pooling(data2d: np.ndarray, window_size: Tuple[int, int]) -> np.ndarray:
     """Average pool ``data2d`` using ``window_size``."""
-    windows = skimage.util.view_as_blocks(data2d, window_size)
+    windows = util.view_as_blocks(data2d, window_size)
     avg = np.average(windows, axis=(2, 3))
     return avg / np.max(avg)
 


### PR DESCRIPTION
## Summary
- adjust RectangleSelector args for newer matplotlib
- fix view_as_blocks call in pooling helper
- update README to reflect expected 3-D input layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68761593f44c8321a8bd4f941b505c0a